### PR TITLE
Update dbConnect.php

### DIFF
--- a/web/0215_demo_notes/dbConnect.php
+++ b/web/0215_demo_notes/dbConnect.php
@@ -17,7 +17,8 @@ function get_db() {
 
 		if (!isset($dbUrl) || empty($dbUrl)) {
 			// example localhost configuration URL with user: "ta_user", password: "ta_pass"
-			// and a database called "scripture_ta"
+			// and a database called "scripture_ta". NOTE: Postgres default port number is 
+			// sometimes set to 5433
 			$dbUrl = "postgres://note_user:orange@localhost:5432/notebook";
 
 			// NOTE: It is not great to put this sensitive information right


### PR DESCRIPTION
Hey Br. Burton,

I had an issue that had me stuck on today's assignment for a significant amount of class time. For some reason, my default Postgres port was 5433. I installed Postgres 9.6 on Windows. From what I've seen online, this sometimes happens although I'm not quite sure why. I think it might depend on what device you run PSQL from (I ran it from a desktop application called "PSQL").